### PR TITLE
ci: add a Linux aarch64 build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,6 +23,10 @@ include:
   # Linux 64-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-x64.yml'
+
+  # Linux ARM 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-aarch64.yml'
  
    # Linux 32-bit
   - project: 'libretro-infrastructure/ci-templates'
@@ -126,6 +130,12 @@ libretro-build-windows-i686:
 libretro-build-linux-x64:
   extends:
     - .libretro-linux-x64-make-default
+    - .core-defs
+
+# Linux ARM 64-bit
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-linux-aarch64-make-default
     - .core-defs
 
 # Linux 32-bit


### PR DESCRIPTION
The libretro buildbot ships no aarch64 Linux build of tamalibretro, so the core can't be installed from RetroArch's Core Downloader on ARM64 Linux machines (ARM Chromebooks, SBCs, ARM laptops). Nothing blocks it: TamaLIB is portable C with no x86-specific code, the `unix` branch of the Makefile is arch-neutral (the only ARM flags live inside the `rpi*` and `classic_*` platform checks), and `android-arm64-v8a`, `osx-arm64`, `ios-arm64` and `tvos-arm64` already build these sources for ARM64.

The job mirrors `libretro-build-linux-x64`:

```yaml
# Linux ARM 64-bit
libretro-build-linux-aarch64:
  extends:
    - .libretro-linux-aarch64-make-default
    - .core-defs
```

plus the matching `/linux-aarch64.yml` template include. `GIT_SUBMODULE_STRATEGY: recursive` from `.core-defs` applies unchanged, so `tamalib/` and `libretro-common/` are checked out as for the other targets.

Verified natively on aarch64 (postmarketOS, glibc, GCC 15): `make platform=unix` builds clean with no source changes, producing `tamalibretro_libretro.so` (ELF 64-bit ARM aarch64), and the core loads in a libretro host. I did not run a game on it - that needs a Tamagotchi P1 ROM dump, which I can't obtain legitimately - so this is a build/load verification only.
